### PR TITLE
Self allocate lp token ids

### DIFF
--- a/frame/dex/src/mock.rs
+++ b/frame/dex/src/mock.rs
@@ -27,7 +27,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, ConstU32, ConstU64},
 	PalletId,
 };
-use frame_system::EnsureSigned;
+use frame_system::{EnsureSigned, EnsureSignedBy};
 use sp_core::H256;
 use sp_keystore::{testing::KeyStore, KeystoreExt};
 use sp_runtime::{
@@ -48,7 +48,7 @@ construct_runtime!(
 		System: frame_system,
 		Balances: pallet_balances,
 		Assets: pallet_assets::<Instance1>,
-		PoolAssets:  pallet_assets::<Instance2>,
+		PoolAssets: pallet_assets::<Instance2>,
 		Dex: pallet_dex,
 	}
 );
@@ -110,14 +110,13 @@ impl pallet_assets::Config<Instance1> for Test {
 	type Extra = ();
 }
 
-//TODO: limit creation only to dex pallet
 impl pallet_assets::Config<Instance2> for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = u64;
 	type AssetId = u32;
 	type Currency = Balances;
 	type ForceOrigin = frame_system::EnsureRoot<u64>;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<u64>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSignedBy<DexAccount, u64>>;
 	type AssetDeposit = ConstU64<0>;
 	type AssetAccountDeposit = ConstU64<0>;
 	type MetadataDepositBase = ConstU64<0>;
@@ -131,6 +130,10 @@ impl pallet_assets::Config<Instance2> for Test {
 
 parameter_types! {
 	pub const DexPalletId: PalletId = PalletId(*b"py/dexer");
+}
+
+frame_support::ord_parameter_types! {
+	pub const DexAccount: u64 = 33; //TODO: this should be DexPalletId
 }
 
 impl Config for Test {

--- a/frame/dex/src/mock.rs
+++ b/frame/dex/src/mock.rs
@@ -143,6 +143,7 @@ impl Config for Test {
 	type Assets = Assets;
 	type PoolAssets = PoolAssets;
 	type AssetId = u32;
+	type PoolAssetId = u32;
 	type PalletId = DexPalletId;
 }
 

--- a/frame/dex/src/types.rs
+++ b/frame/dex/src/types.rs
@@ -19,11 +19,11 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 #[derive(Encode, Decode, Default, PartialEq, Eq, MaxEncodedLen, TypeInfo)]
-pub struct PoolInfo<AccountId, AssetId, Balance> {
+pub struct PoolInfo<AccountId, AssetId, PoolAssetId, Balance> {
 	/// Owner of the pool
 	pub owner: AccountId,
-	/// LP asset
-	pub lp_token: AssetId,
+	/// Liquidity pool asset
+	pub lp_token: PoolAssetId,
 	/// The first asset supported by the pool
 	pub asset1: AssetId,
 	/// The second asset supported by the pool

--- a/frame/support/src/traits.rs
+++ b/frame/support/src/traits.rs
@@ -91,7 +91,7 @@ pub mod schedule;
 mod storage;
 pub use storage::{
 	Instance, PartialStorageInfoTrait, StorageInfo, StorageInfoTrait, StorageInstance,
-	TrackedStorageKey, WhitelistedStorageKeys,
+	TrackedStorageKey, WhitelistedStorageKeys, Incrementable,
 };
 
 mod dispatch;

--- a/frame/support/src/traits/storage.rs
+++ b/frame/support/src/traits/storage.rs
@@ -21,6 +21,7 @@ use crate::sp_std::collections::btree_set::BTreeSet;
 use impl_trait_for_tuples::impl_for_tuples;
 pub use sp_core::storage::TrackedStorageKey;
 use sp_std::prelude::*;
+use sp_runtime::traits::Saturating;
 
 /// An instance of a pallet in the storage.
 ///
@@ -118,3 +119,29 @@ impl WhitelistedStorageKeys for Tuple {
 		combined_keys.into_iter().collect::<Vec<_>>()
 	}
 }
+
+macro_rules! impl_incrementable {
+	($($type:ty),+) => {
+		$(
+			impl Incrementable for $type {
+				fn increment(&self) -> Self {
+					let mut val = self.clone();
+					val.saturating_inc();
+					val
+				}
+
+				fn initial_value() -> Self {
+					0
+				}
+			}
+		)+
+	};
+}
+
+/// For example: allows new identifiers to be created in a linear fashion.
+pub trait Incrementable {
+	fn increment(&self) -> Self;
+	fn initial_value() -> Self;
+}
+
+impl_incrementable!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);


### PR DESCRIPTION
Rather than leave allocation to the user it's better UX and probably safer if we choose the lp asset ids ourselves.

(There's also a little set CreateOrigin in there too but that's not there yet.)