### PR TITLE
always swap with native currency.

### DIFF
--- a/frame/dex/README.md
+++ b/frame/dex/README.md
@@ -1,0 +1,118 @@
+# Decentralized exchange pallet
+
+Substrate DEX pallet based on Uniswap V1/V2 logic.
+
+## Overview
+
+This pallet allows to:
+ - create a liquidity pool for the native asset and another asset
+ - provide the liquidity and receive back an LP asset
+ - exchange the LP asset back to assets
+ - swap asset for native and native for asset if there is a pool created
+ - query for an exchange price via a new RPC endpoint
+
+## RPC usage
+
+```shell
+curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
+     "jsonrpc":"2.0",
+      "id":1,
+      "method":"dex_quotePrice",
+      "params": [1, 2, 100]
+    }'
+```
+where:
+ - `params[0]` - asset1 id
+ - `params[1]` - asset2 id
+ - `params[2]` - amount to swap
+
+## Pallet extrinsics
+
+```rust
+
+    // Creates a pool. `lp_asset` is stored in a separate asset registry.
+    pub fn create_pool(
+      origin: OriginFor<T>,
+      asset1: AssetIdOf<T>,
+      asset2: AssetIdOf<T>,
+      lp_asset: AssetIdOf<T>,
+    ) -> DispatchResult;
+
+    // Provide liquidity into the pool of `asset1` and `asset2`
+    // NOTE: an optimal amount of asset1 and asset2 will be calculated and
+    // might be different to provided `amount1_desired`/`amount2_desired`
+    // thus it's needed to provide the min amount you're happy to provide.
+    // Params `amount1_min`/`amount2_min` represent that.
+    pub fn add_liquidity(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      amount_native_desired: BalanceOf<T>,
+      amount_asset_desired: AssetBalanceOf<T>,
+      amount_native_min: BalanceOf<T>,
+      amount_asset_min: AssetBalanceOf<T>,
+      mint_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+
+    // Allows to remove the liquidity by providing an lp token.
+    // With the usage of `amount1_min`/`amount2_min` it's possible to control
+    // the min amount of returned tokens you're happy with.
+    pub fn remove_liquidity(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      liquidity: AssetBalanceOf<T>,
+      amount_native_min: BalanceOf<T>,
+      amount_asset_min: AssetBalanceOf<T>,
+      withdraw_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+
+    // Swap the exact amount of `asset1` into `asset2`.
+    // `amount_out_min` param allows to specify the min amount of the `asset2`
+    // you're happy to receive.
+    pub fn buy_exact_native_for_assset(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      amount_out: AssetBalanceOf<T>,
+      amount_in_min: AssetBalanceOf<T>,
+      send_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+
+    // Swap any amount of `asset1` to get the exact amount of `asset2`.
+    // `amount_in_max` param allows to specify the max amount of the `asset1`
+    // you're happy to provide.
+    pub fn sell_exact_asset_for_native(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      amount_in: AssetBalanceOf<T>,
+      amount_out_min: AssetBalanceOf<T>,
+      send_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+
+
+    // Swap the exact amount of `asset1` into `asset2`.
+    // `amount_out_min` param allows to specify the min amount of the `asset2`
+    // you're happy to receive.
+    pub fn buy_asset_for_exact_native(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      amount_in: AssetBalanceOf<T>,
+      amount_out_max: AssetBalanceOf<T>,
+      send_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+
+    // Swap any amount of `asset1` to get the exact amount of `asset2`.
+    // `amount_in_max` param allows to specify the max amount of the `asset1`
+    // you're happy to provide.
+    pub fn sell_tokens_for_exact_asset(
+      origin: OriginFor<T>,
+      asset_id: AssetIdOf<T>,
+      amount_out: AssetBalanceOf<T>,
+      amount_in_max: AssetBalanceOf<T>,
+      send_to: T::AccountId,
+      deadline: T::BlockNumber,
+    ) -> DispatchResult;
+```

--- a/frame/dex/src/tests.rs
+++ b/frame/dex/src/tests.rs
@@ -31,7 +31,7 @@ fn events() -> Vec<Event<Test>> {
 	result
 }
 
-fn pools() -> Vec<PoolIdOf<Test>> {
+fn pools() -> Vec<u32> {
 	let mut s: Vec<_> = Pools::<Test>::iter().map(|x| x.0).collect();
 	s.sort();
 	s
@@ -53,42 +53,42 @@ fn pool_assets() -> Vec<u32> {
 	s
 }
 
-fn create_tokens(owner: u64, tokens: Vec<u32>) {
-	for token_id in tokens {
-		assert_ok!(Assets::force_create(RuntimeOrigin::root(), token_id, owner, true, 1));
+fn create_assets(owner: u64, assets: Vec<u32>) {
+	for asset_id in assets {
+		assert_ok!(Assets::force_create(RuntimeOrigin::root(), asset_id, owner, true, 1));
 	}
 }
 
-fn balance(owner: u64, token_id: u32) -> u64 {
-	<<Test as Config>::Assets>::balance(token_id, owner)
+fn balance(owner: u64, asset_id: u32) -> u64 {
+	<<Test as Config>::Assets>::balance(asset_id, owner)
 }
 
 fn currency_balance(owner: u64) -> u64 {
 	<<Test as Config>::Currency>::free_balance(owner)
 }
 
-fn pool_balance(owner: u64, token_id: u32) -> u64 {
-	<<Test as Config>::PoolAssets>::balance(token_id, owner)
+fn pool_balance(owner: u64, lp_asset_id: u32) -> u64 {
+	<<Test as Config>::PoolAssets>::balance(lp_asset_id, owner)
 }
 
 #[test]
 fn create_pool_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		// let token_1 = 1;
-		let token_2 = 2;
-		let pool_id = token_2;
+		// let asset_1 = 1;
+		let asset_2 = 2;
+		let asset_id = asset_2;
 
-		create_tokens(user, vec![token_2]);
+		create_assets(user, vec![asset_2]);
 
-		let lp_token: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
-		assert_eq!(lp_token + 1, Dex::get_next_pool_asset_id());
+		let lp_asset: u32 = Dex::get_next_pool_asset_id();
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
+		assert_eq!(lp_asset + 1, Dex::get_next_pool_asset_id());
 
-		assert_eq!(events(), [Event::<Test>::PoolCreated { creator: user, pool_id, lp_token }]);
-		assert_eq!(pools(), vec![pool_id]);
-		assert_eq!(assets(), vec![token_2]);
-		assert_eq!(pool_assets(), vec![lp_token]);
+		assert_eq!(events(), [Event::<Test>::PoolCreated { creator: user, asset_id, lp_asset }]);
+		assert_eq!(pools(), vec![asset_id]);
+		assert_eq!(assets(), vec![asset_2]);
+		assert_eq!(pool_assets(), vec![lp_asset]);
 	});
 }
 
@@ -96,17 +96,17 @@ fn create_pool_should_work() {
 fn create_same_pool_twice_should_fail() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
+		let asset_2 = 2;
 
-		create_tokens(user, vec![token_2]);
+		create_assets(user, vec![asset_2]);
 
-		let lp_token: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
-		let expected_free = lp_token + 1;
+		let lp_asset: u32 = Dex::get_next_pool_asset_id();
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
+		let expected_free = lp_asset + 1;
 		assert_eq!(expected_free, Dex::get_next_pool_asset_id());
 
 		assert_noop!(
-			Dex::create_pool(RuntimeOrigin::signed(user), token_2),
+			Dex::create_pool(RuntimeOrigin::signed(user), asset_2),
 			Error::<Test>::PoolExists
 		);
 		assert_eq!(expected_free, Dex::get_next_pool_asset_id());
@@ -114,40 +114,40 @@ fn create_same_pool_twice_should_fail() {
 }
 
 #[test]
-fn different_pools_should_have_different_lp_tokens() {
+fn different_pools_should_have_different_lp_assets() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
-		let token_3 = 3;
-		let pool_id_1_2 = token_2;
-		let pool_id_1_3 = token_3;
+		let asset_2 = 2;
+		let asset_3 = 3;
+		let pool_id_1_2 = asset_2;
+		let pool_id_1_3 = asset_3;
 
-		create_tokens(user, vec![token_2]);
+		create_assets(user, vec![asset_2]);
 
-		let lp_token2_1: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
-		let lp_token3_1: u32 = Dex::get_next_pool_asset_id();
+		let lp_asset2_1: u32 = Dex::get_next_pool_asset_id();
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
+		let lp_asset3_1: u32 = Dex::get_next_pool_asset_id();
 
 		assert_eq!(
 			events(),
 			[Event::<Test>::PoolCreated {
 				creator: user,
-				pool_id: pool_id_1_2,
-				lp_token: lp_token2_1
+				asset_id: pool_id_1_2,
+				lp_asset: lp_asset2_1
 			}]
 		);
 
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_3));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_3));
 		assert_eq!(
 			events(),
 			[Event::<Test>::PoolCreated {
 				creator: user,
-				pool_id: pool_id_1_3,
-				lp_token: lp_token3_1
+				asset_id: pool_id_1_3,
+				lp_asset: lp_asset3_1
 			}]
 		);
 
-		assert_ne!(lp_token2_1, lp_token3_1);
+		assert_ne!(lp_asset2_1, lp_asset3_1);
 	});
 }
 
@@ -155,19 +155,19 @@ fn different_pools_should_have_different_lp_tokens() {
 fn add_liquidity_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
-		let pool_id = token_2;
+		let asset_2 = 2;
+		let asset_id = asset_2;
 
-		create_tokens(user, vec![token_2]);
-		let lp_token = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
+		create_assets(user, vec![asset_2]);
+		let lp_asset = Dex::get_next_pool_asset_id();
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
 
 		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), asset_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_2,
+			asset_2,
 			10,
 			10,
 			10,
@@ -179,17 +179,17 @@ fn add_liquidity_should_work() {
 		assert!(events().contains(&Event::<Test>::LiquidityAdded {
 			who: user,
 			mint_to: user,
-			pool_id,
-			amount1_provided: 10,
-			amount2_provided: 10,
-			lp_token,
+			asset_id,
+			amount_native_provided: 10,
+			amount_asset_provided: 10,
+			lp_asset,
 			liquidity: 9,
 		}));
 
 		let pallet_account = Dex::account_id();
 		assert_eq!(currency_balance(pallet_account), 10);
-		assert_eq!(balance(pallet_account, token_2), 10);
-		assert_eq!(pool_balance(user, lp_token), 9);
+		assert_eq!(balance(pallet_account, asset_2), 10);
+		assert_eq!(pool_balance(user, lp_asset), 9);
 	});
 }
 
@@ -197,20 +197,19 @@ fn add_liquidity_should_work() {
 fn remove_liquidity_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
-		let pool_id = token_2;
+		let asset_2 = 2;
+		let asset_id = asset_2;
 
-		create_tokens(user, vec![token_2]);
-		let lp_token = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
+		create_assets(user, vec![asset_2]);
+		let lp_asset = Dex::get_next_pool_asset_id();
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
 
 		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), asset_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			// token_1,
-			token_2,
+			asset_2,
 			10,
 			10,
 			10,
@@ -219,26 +218,26 @@ fn remove_liquidity_should_work() {
 			2
 		));
 
-		assert_ok!(Dex::remove_liquidity(RuntimeOrigin::signed(user), token_2, 9, 0, 0, user, 2));
+		assert_ok!(Dex::remove_liquidity(RuntimeOrigin::signed(user), asset_2, 9, 0, 0, user, 2));
 
 		assert!(events().contains(&Event::<Test>::LiquidityRemoved {
 			who: user,
 			withdraw_to: user,
-			pool_id,
-			amount1: 9,
-			amount2: 9,
-			lp_token,
+			asset_id,
+			amount_native_withdrawn: 9,
+			amount_asset_withdrawn: 9,
+			lp_asset,
 			liquidity: 9,
 		}));
 
 		let pallet_account = Dex::account_id();
 		assert_eq!(currency_balance(pallet_account), 1);
-		assert_eq!(balance(pallet_account, token_2), 1);
-		assert_eq!(pool_balance(pallet_account, lp_token), 1);
+		assert_eq!(balance(pallet_account, asset_2), 1);
+		assert_eq!(pool_balance(pallet_account, lp_asset), 1);
 
 		assert_eq!(currency_balance(user), 999);
-		assert_eq!(balance(user, token_2), 999);
-		assert_eq!(pool_balance(user, lp_token), 0);
+		assert_eq!(balance(user, asset_2), 999);
+		assert_eq!(pool_balance(user, lp_asset), 0);
 	});
 }
 
@@ -246,17 +245,17 @@ fn remove_liquidity_should_work() {
 fn quote_price_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
+		let asset_2 = 2;
 
-		create_tokens(user, vec![token_2]);
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
+		create_assets(user, vec![asset_2]);
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
 
 		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), asset_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_2,
+			asset_2,
 			1000,
 			20,
 			1,
@@ -265,28 +264,28 @@ fn quote_price_should_work() {
 			2
 		));
 
-		assert_eq!(Dex::quote_tokens(token_2, 3000), Some(60));
+		assert_eq!(Dex::quote_asset(asset_2, 3000), Some(60));
 	});
 }
 
 #[test]
-fn sell_exact_tokens_for_native_should_work() {
+fn sell_exact_asset_for_native_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_2 = 2;
+		let asset_2 = 2;
 		let deadline = 2;
 
-		create_tokens(user, vec![token_2]);
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
+		create_assets(user, vec![asset_2]);
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), asset_2));
 
 		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
+		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), asset_2, user, 1000));
 
 		let liquidity1 = 1000;
 		let liquidity2 = 20;
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_2,
+			asset_2,
 			liquidity1,
 			liquidity2,
 			1,
@@ -298,9 +297,9 @@ fn sell_exact_tokens_for_native_should_work() {
 		assert_eq!(currency_balance(user), 0);
 
 		let exchange_amount = 10;
-		assert_ok!(Dex::sell_exact_tokens_for_native(
+		assert_ok!(Dex::sell_exact_asset_for_native(
 			RuntimeOrigin::signed(user),
-			token_2,
+			asset_2,
 			exchange_amount,
 			1,
 			user,
@@ -312,6 +311,6 @@ fn sell_exact_tokens_for_native_should_work() {
 		let pallet_account = Dex::account_id();
 		assert_eq!(currency_balance(user), expect_receive);
 		assert_eq!(currency_balance(pallet_account), liquidity1 - expect_receive);
-		assert_eq!(balance(pallet_account, token_2), liquidity2 + exchange_amount);
+		assert_eq!(balance(pallet_account, asset_2), liquidity2 + exchange_amount);
 	});
 }

--- a/frame/dex/src/tests.rs
+++ b/frame/dex/src/tests.rs
@@ -17,10 +17,7 @@
 
 use crate::{mock::*, *};
 
-use frame_support::{
-	assert_noop, assert_ok,
-	traits::{fungibles::InspectEnumerable, Currency},
-};
+use frame_support::{assert_noop, assert_ok, traits::fungibles::InspectEnumerable};
 
 fn events() -> Vec<Event<Test>> {
 	let result = System::events()
@@ -62,13 +59,12 @@ fn create_tokens(owner: u64, tokens: Vec<u32>) {
 	}
 }
 
-fn topup_pallet() {
-	let pallet_account = Dex::account_id();
-	Balances::make_free_balance_be(&pallet_account, 10000);
-}
-
 fn balance(owner: u64, token_id: u32) -> u64 {
 	<<Test as Config>::Assets>::balance(token_id, owner)
+}
+
+fn currency_balance(owner: u64) -> u64 {
+	<<Test as Config>::Currency>::free_balance(owner)
 }
 
 fn pool_balance(owner: u64, token_id: u32) -> u64 {
@@ -79,20 +75,19 @@ fn pool_balance(owner: u64, token_id: u32) -> u64 {
 fn create_pool_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
+		// let token_1 = 1;
 		let token_2 = 2;
-		let pool_id = (token_1, token_2);
-		topup_pallet();
+		let pool_id = token_2;
 
-		create_tokens(user, vec![token_1, token_2]);
+		create_tokens(user, vec![token_2]);
 
 		let lp_token: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2, token_1));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 		assert_eq!(lp_token + 1, Dex::get_next_pool_asset_id());
 
 		assert_eq!(events(), [Event::<Test>::PoolCreated { creator: user, pool_id, lp_token }]);
 		assert_eq!(pools(), vec![pool_id]);
-		assert_eq!(assets(), vec![token_1, token_2]);
+		assert_eq!(assets(), vec![token_2]);
 		assert_eq!(pool_assets(), vec![lp_token]);
 	});
 }
@@ -101,26 +96,17 @@ fn create_pool_should_work() {
 fn create_same_pool_twice_should_fail() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
-		topup_pallet();
 
-		create_tokens(user, vec![token_1, token_2]);
+		create_tokens(user, vec![token_2]);
 
 		let lp_token: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2, token_1));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 		let expected_free = lp_token + 1;
 		assert_eq!(expected_free, Dex::get_next_pool_asset_id());
 
 		assert_noop!(
-			Dex::create_pool(RuntimeOrigin::signed(user), token_2, token_1),
-			Error::<Test>::PoolExists
-		);
-		assert_eq!(expected_free, Dex::get_next_pool_asset_id());
-
-		// Try switching the same tokens around:
-		assert_noop!(
-			Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_2),
+			Dex::create_pool(RuntimeOrigin::signed(user), token_2),
 			Error::<Test>::PoolExists
 		);
 		assert_eq!(expected_free, Dex::get_next_pool_asset_id());
@@ -131,17 +117,15 @@ fn create_same_pool_twice_should_fail() {
 fn different_pools_should_have_different_lp_tokens() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
 		let token_3 = 3;
-		let pool_id_1_2 = (token_1, token_2);
-		let pool_id_1_3 = (token_1, token_3);
-		topup_pallet();
+		let pool_id_1_2 = token_2;
+		let pool_id_1_3 = token_3;
 
-		create_tokens(user, vec![token_1, token_2]);
+		create_tokens(user, vec![token_2]);
 
 		let lp_token2_1: u32 = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2, token_1));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 		let lp_token3_1: u32 = Dex::get_next_pool_asset_id();
 
 		assert_eq!(
@@ -153,7 +137,7 @@ fn different_pools_should_have_different_lp_tokens() {
 			}]
 		);
 
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_3, token_1));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_3));
 		assert_eq!(
 			events(),
 			[Event::<Test>::PoolCreated {
@@ -171,21 +155,18 @@ fn different_pools_should_have_different_lp_tokens() {
 fn add_liquidity_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
-		let pool_id = (token_1, token_2);
-		topup_pallet();
+		let pool_id = token_2;
 
-		create_tokens(user, vec![token_1, token_2]);
+		create_tokens(user, vec![token_2]);
 		let lp_token = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_2));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_1, user, 1000));
+		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_1,
 			token_2,
 			10,
 			10,
@@ -206,7 +187,7 @@ fn add_liquidity_should_work() {
 		}));
 
 		let pallet_account = Dex::account_id();
-		assert_eq!(balance(pallet_account, token_1), 10);
+		assert_eq!(currency_balance(pallet_account), 10);
 		assert_eq!(balance(pallet_account, token_2), 10);
 		assert_eq!(pool_balance(user, lp_token), 9);
 	});
@@ -216,21 +197,19 @@ fn add_liquidity_should_work() {
 fn remove_liquidity_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
-		let pool_id = (token_1, token_2);
-		topup_pallet();
+		let pool_id = token_2;
 
-		create_tokens(user, vec![token_1, token_2]);
+		create_tokens(user, vec![token_2]);
 		let lp_token = Dex::get_next_pool_asset_id();
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_2));
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_1, user, 1000));
+		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_1,
+			// token_1,
 			token_2,
 			10,
 			10,
@@ -240,16 +219,7 @@ fn remove_liquidity_should_work() {
 			2
 		));
 
-		assert_ok!(Dex::remove_liquidity(
-			RuntimeOrigin::signed(user),
-			token_1,
-			token_2,
-			9,
-			0,
-			0,
-			user,
-			2
-		));
+		assert_ok!(Dex::remove_liquidity(RuntimeOrigin::signed(user), token_2, 9, 0, 0, user, 2));
 
 		assert!(events().contains(&Event::<Test>::LiquidityRemoved {
 			who: user,
@@ -262,11 +232,11 @@ fn remove_liquidity_should_work() {
 		}));
 
 		let pallet_account = Dex::account_id();
-		assert_eq!(balance(pallet_account, token_1), 1);
+		assert_eq!(currency_balance(pallet_account), 1);
 		assert_eq!(balance(pallet_account, token_2), 1);
 		assert_eq!(pool_balance(pallet_account, lp_token), 1);
 
-		assert_eq!(balance(user, token_1), 999);
+		assert_eq!(currency_balance(user), 999);
 		assert_eq!(balance(user, token_2), 999);
 		assert_eq!(pool_balance(user, lp_token), 0);
 	});
@@ -276,19 +246,16 @@ fn remove_liquidity_should_work() {
 fn quote_price_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
-		topup_pallet();
 
-		create_tokens(user, vec![token_1, token_2]);
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_2));
+		create_tokens(user, vec![token_2]);
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_1, user, 1000));
+		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
 
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_1,
 			token_2,
 			1000,
 			20,
@@ -298,45 +265,42 @@ fn quote_price_should_work() {
 			2
 		));
 
-		assert_eq!(Dex::quote_price(token_1, token_2, 3000), Some(60));
+		assert_eq!(Dex::quote_tokens(token_2, 3000), Some(60));
 	});
 }
 
 #[test]
-fn swap_should_work() {
+fn sell_exact_tokens_for_native_should_work() {
 	new_test_ext().execute_with(|| {
 		let user = 1;
-		let token_1 = 1;
 		let token_2 = 2;
-		topup_pallet();
+		let deadline = 2;
 
-		create_tokens(user, vec![token_1, token_2]);
-		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_2));
+		create_tokens(user, vec![token_2]);
+		assert_ok!(Dex::create_pool(RuntimeOrigin::signed(user), token_2));
 
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_1, user, 1000));
+		assert_ok!(Balances::set_balance(RuntimeOrigin::root(), user, 1000, 0));
 		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_2, user, 1000));
 
 		let liquidity1 = 1000;
 		let liquidity2 = 20;
 		assert_ok!(Dex::add_liquidity(
 			RuntimeOrigin::signed(user),
-			token_1,
 			token_2,
 			liquidity1,
 			liquidity2,
 			1,
 			1,
 			user,
-			2
+			deadline
 		));
 
-		assert_eq!(balance(user, token_1), 0);
+		assert_eq!(currency_balance(user), 0);
 
 		let exchange_amount = 10;
-		assert_ok!(Dex::swap_exact_tokens_for_tokens(
+		assert_ok!(Dex::sell_exact_tokens_for_native(
 			RuntimeOrigin::signed(user),
 			token_2,
-			token_1,
 			exchange_amount,
 			1,
 			user,
@@ -344,58 +308,10 @@ fn swap_should_work() {
 		));
 
 		let expect_receive =
-			Dex::get_amount_out(&exchange_amount, &liquidity2, &liquidity1).ok().unwrap();
+			Dex::get_native_out(&exchange_amount, &liquidity2, &liquidity1).ok().unwrap();
 		let pallet_account = Dex::account_id();
-		assert_eq!(balance(user, token_1), expect_receive);
-		assert_eq!(balance(pallet_account, token_1), liquidity1 - expect_receive);
+		assert_eq!(currency_balance(user), expect_receive);
+		assert_eq!(currency_balance(pallet_account), liquidity1 - expect_receive);
 		assert_eq!(balance(pallet_account, token_2), liquidity2 + exchange_amount);
-	});
-}
-
-#[test]
-fn same_asset_swap_should_fail() {
-	new_test_ext().execute_with(|| {
-		let user = 1;
-		let token_1 = 1;
-		topup_pallet();
-
-		create_tokens(user, vec![token_1]);
-		assert_noop!(
-			Dex::create_pool(RuntimeOrigin::signed(user), token_1, token_1),
-			Error::<Test>::EqualAssets
-		);
-
-		assert_ok!(Assets::mint(RuntimeOrigin::signed(user), token_1, user, 1000));
-
-		let liquidity1 = 1000;
-		let liquidity2 = 20;
-		assert_noop!(
-			Dex::add_liquidity(
-				RuntimeOrigin::signed(user),
-				token_1,
-				token_1,
-				liquidity1,
-				liquidity2,
-				1,
-				1,
-				user,
-				2
-			),
-			Error::<Test>::PoolNotFound
-		);
-
-		let exchange_amount = 10;
-		assert_noop!(
-			Dex::swap_exact_tokens_for_tokens(
-				RuntimeOrigin::signed(user),
-				token_1,
-				token_1,
-				exchange_amount,
-				1,
-				user,
-				3
-			),
-			Error::<Test>::PoolNotFound
-		);
 	});
 }

--- a/frame/dex/src/types.rs
+++ b/frame/dex/src/types.rs
@@ -19,17 +19,15 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 #[derive(Encode, Decode, Default, PartialEq, Eq, MaxEncodedLen, TypeInfo)]
-pub struct PoolInfo<AccountId, AssetId, PoolAssetId, Balance> {
+pub struct PoolInfo<AccountId, AssetId, PoolAssetId, NativeBalance, AssetBalance> {
 	/// Owner of the pool
 	pub owner: AccountId,
 	/// Liquidity pool asset
 	pub lp_token: PoolAssetId,
-	/// The first asset supported by the pool
-	pub asset1: AssetId,
-	/// The second asset supported by the pool
-	pub asset2: AssetId,
-	/// Pool balance of asset1
-	pub balance1: Balance,
+	/// The second asset supported by the pool (first is the native currency)
+	pub token_asset_id: AssetId,
+	/// Pool balance of asset1 (native currency)
+	pub balance_native: NativeBalance,
 	/// Pool balance of asset2
-	pub balance2: Balance,
+	pub balance_token: AssetBalance,
 }

--- a/frame/dex/src/types.rs
+++ b/frame/dex/src/types.rs
@@ -23,11 +23,11 @@ pub struct PoolInfo<AccountId, AssetId, PoolAssetId, NativeBalance, AssetBalance
 	/// Owner of the pool
 	pub owner: AccountId,
 	/// Liquidity pool asset
-	pub lp_token: PoolAssetId,
+	pub lp_asset: PoolAssetId,
 	/// The second asset supported by the pool (first is the native currency)
-	pub token_asset_id: AssetId,
-	/// Pool balance of asset1 (native currency)
+	pub asset_id: AssetId,
+	/// Pool balance of the native currency
 	pub balance_native: NativeBalance,
-	/// Pool balance of asset2
-	pub balance_token: AssetBalance,
+	/// Pool balance of the other asset
+	pub balance_asset: AssetBalance,
 }


### PR DESCRIPTION
This is one way to support swapping with only the Balances pallet as one side of every pair.
The swap methods have been split out into buy / sell methods to make the logic clearer.

(Separate asset instances can be handled by multiple dex instances as now there is no cross asset-instances pair.)