### PR TITLE
remove balances

### DIFF
--- a/frame/dex/src/lib.rs
+++ b/frame/dex/src/lib.rs
@@ -42,9 +42,8 @@ pub const MIN_LIQUIDITY: u64 = 1;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::pallet_prelude::*;
+	use frame_support::{pallet_prelude::*, sp_io};
 	use frame_system::pallet_prelude::*;
-	use frame_support::sp_io;
 
 	use frame_support::{
 		traits::{
@@ -131,10 +130,7 @@ pub mod pallet {
 		_,
 		Blake2_128Concat,
 		PoolIdOf<T>,
-		PoolInfo<T::AccountId,
-			// T::AssetId,
-			 T::PoolAssetId
-		>,
+		PoolInfo<T::AccountId, T::PoolAssetId>,
 		OptionQuery,
 	>;
 
@@ -248,10 +244,7 @@ pub mod pallet {
 			T::PoolAssets::create(lp_token, pool_account.clone(), true, MIN_LIQUIDITY.into())?;
 			T::PoolAssets::set(lp_token, &pool_account, "LP".into(), "LP".into(), 0)?;
 
-			let pool_info = PoolInfo {
-				owner: sender.clone(),
-				lp_token,
-			};
+			let pool_info = PoolInfo { owner: sender.clone(), lp_token };
 
 			Pools::<T>::insert(pool_id, pool_info);
 
@@ -259,8 +252,6 @@ pub mod pallet {
 
 			Ok(())
 		}
-
-
 
 		#[pallet::weight(T::WeightInfo::add_liquidity())]
 		pub fn add_liquidity(
@@ -485,7 +476,7 @@ pub mod pallet {
 			let balance1 = Self::get_balance(&pool_account, asset1);
 			let balance2 = Self::get_balance(&pool_account, asset2);
 			if balance1.is_zero() {
-				return Err(Error::<T>::PoolNotFound.into());
+				return Err(Error::<T>::PoolNotFound.into())
 			}
 
 			let amount_out = Self::get_amount_out(&amount_in, &balance1, &balance2)?;
@@ -538,7 +529,7 @@ pub mod pallet {
 			let balance1 = Self::get_balance(&pool_account, asset1);
 			let balance2 = Self::get_balance(&pool_account, asset2);
 			if balance1.is_zero() {
-				return Err(Error::<T>::PoolNotFound.into());
+				return Err(Error::<T>::PoolNotFound.into())
 			}
 
 			let amount_in = Self::get_amount_in(&amount_out, &balance1, &balance2)?;
@@ -588,7 +579,10 @@ pub mod pallet {
 			T::PalletId::get().into_sub_account_truncating(sub)
 		}
 
-		fn get_balance(owner: &T::AccountId, token_id: MultiAssetId<T::AssetId>) -> T::AssetBalance {
+		fn get_balance(
+			owner: &T::AccountId,
+			token_id: MultiAssetId<T::AssetId>,
+		) -> T::AssetBalance {
 			match token_id {
 				MultiAssetId::Native => <<T as Config>::Currency>::balance(owner),
 				MultiAssetId::Asset(token_id) => <<T as Config>::Assets>::balance(token_id, owner),
@@ -630,11 +624,8 @@ pub mod pallet {
 			if !balance1.is_zero() {
 				let balance2 = Self::get_balance(&pool_account, asset2);
 
-				let (reserve1, reserve2) = if asset1 == pool_asset1 {
-					(balance1, balance2)
-				} else {
-					(balance2, balance1)
-				};
+				let (reserve1, reserve2) =
+					if asset1 == pool_asset1 { (balance1, balance2) } else { (balance2, balance1) };
 				Self::quote(&amount, &reserve1, &reserve2).ok()
 			} else {
 				None

--- a/frame/dex/src/lib.rs
+++ b/frame/dex/src/lib.rs
@@ -432,9 +432,6 @@ pub mod pallet {
 				Self::transfer(asset1, &pool_account, &withdraw_to, amount1, false)?;
 				Self::transfer(asset2, &pool_account, &withdraw_to, amount2, false)?;
 
-				// pool.balance1 = reserve1 - amount1;
-				// pool.balance2 = reserve2 - amount2;
-
 				Self::deposit_event(Event::LiquidityRemoved {
 					who: sender,
 					withdraw_to,
@@ -485,7 +482,7 @@ pub mod pallet {
 
 			Self::transfer(asset1, &sender, &pool_account, amount_in, keep_alive)?;
 
-			ensure!(amount_out < balance2, Error::<T>::InsufficientAmountParam2);
+			ensure!(amount_out < balance2, Error::<T>::InsufficientLiquidity);
 
 			Self::transfer(asset2, &pool_account, &send_to, amount_out, false)?;
 
@@ -537,7 +534,7 @@ pub mod pallet {
 
 			Self::transfer(asset1, &sender, &pool_account, amount_in, keep_alive)?;
 
-			ensure!(amount_out < balance2, Error::<T>::InsufficientAmountParam2);
+			ensure!(amount_out < balance2, Error::<T>::InsufficientLiquidity);
 
 			Self::transfer(asset2, &pool_account, &send_to, amount_out, false)?;
 

--- a/frame/dex/src/types.rs
+++ b/frame/dex/src/types.rs
@@ -39,17 +39,9 @@ pub enum MultiAssetId<AssetId> {
 }
 
 #[derive(Decode, Encode, Default, PartialEq, Eq, MaxEncodedLen, TypeInfo)]
-pub struct PoolInfo<AccountId, AssetId, PoolAssetId, Balance> {
+pub struct PoolInfo<AccountId, PoolAssetId> {
 	/// Owner of the pool
 	pub owner: AccountId,
 	/// Liquidity pool asset
 	pub lp_token: PoolAssetId,
-	/// The first asset supported by the pool
-	pub asset1: MultiAssetId<AssetId>,
-	/// The second asset supported by the pool
-	pub asset2: MultiAssetId<AssetId>,
-	/// Pool balance of asset1
-	pub balance1: Balance,
-	/// Pool balance of asset2
-	pub balance2: Balance,
 }


### PR DESCRIPTION
This removes us manually tracking the balances of the pools.

Incidentally because of how we look up the balances now, we don't have to do any switcheroos which makes the code easier to read.

Also swaps now are not reading or mutating PoolInfo state so weight should be reduced.